### PR TITLE
Fix imports on Python 3

### DIFF
--- a/sphinx_graphiql/__init__.py
+++ b/sphinx_graphiql/__init__.py
@@ -1,4 +1,6 @@
-from sphinx_graphiql import SphinxGraphiQL
+from __future__ import absolute_import
+
+from .sphinx_graphiql import SphinxGraphiQL
 
 def setup(app):
     app.add_directive('graphiql', SphinxGraphiQL)


### PR DESCRIPTION
Use a relative import. This was giving an import error on Python 3.7